### PR TITLE
Incorporate Yelp API for food+events

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,6 +12,8 @@ var favouritesRouter = require('./routes/favourites');
 var videosRouter = require('./routes/videos');
 var authRoutes = require('./routes/auth');
 var placesRouter = require('./routes/places');
+var restaurantsRouter = require('./routes/restaurants');
+var eventsRouter = require('./routes/events');
 
 app.use(cookieSession({
   maxAge: 24*60*60*100,
@@ -46,6 +48,8 @@ app.use(bodyParser.urlencoded({extended: true}));
 app.use('/favourites', favouritesRouter);
 app.use('/findVideos', videosRouter);
 app.use('/findPlaces', placesRouter);
+app.use('/findRestaurants', restaurantsRouter);
+app.use('/findEvents', eventsRouter);
 app.use('/auth', authRoutes);
 
 // catch 404 and forward to error handler

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "passport": "^0.4.1",
     "passport-facebook": "^3.0.0",
     "passport-google-oauth20": "^2.0.0",
-    "passport-local": "^1.0.0"
+    "passport-local": "^1.0.0",
+    "yelp-fusion": "^3.0.0"
   }
 }

--- a/routes/events.js
+++ b/routes/events.js
@@ -1,0 +1,97 @@
+const yelp = require('yelp-fusion');
+var axios = require('axios');
+const { Client } = require('@googlemaps/google-maps-services-js');
+const client = new Client({});
+let axiosInstance = axios.create({});
+const yelpClient = yelp.client('IL2FAbCiYXXpcxEYV6PQVmLctUKFbk5kw-jNKFlx36oMrKjl87A2r6-h8Vs48JiCvyydd7bo0E6ftscdmBEEOC646YYsQCH70GitQwUpR3Yodoa-pAuQREa2LTIbX3Yx');
+var express = require('express');
+var router = express.Router();
+
+let previousQueryCoordinates = {};
+const eventQueryOptions = ['festivals', 'adventure', 'tours'];
+let eventQueryOptionsCounter = 1;
+
+async function getPlaceCoordinates (location) {
+  let coordinates = await client
+    .findPlaceFromText({
+      params: {
+        input: location,
+        inputtype: 'textquery',
+        key: 'AIzaSyAKDqQlGYP74UfAeSQDG6h9bKrN6hA0wAA',
+        fields: ['formatted_address', 'geometry']
+      },
+      timeout: 1000
+    }, axiosInstance);
+  return coordinates;
+}
+
+async function callback (req, res) {
+  let officialCoordinates = {};
+  if (!req.body.getMore) {
+    eventQueryOptionsCounter = 0;
+    getPlaceCoordinates(req.body.destination)
+    .then(coord => {
+      if (coord.data.candidates.length > 0) {
+        officialCoordinates.lat = coord.data.candidates[0].geometry.location.lat;
+        officialCoordinates.lng = coord.data.candidates[0].geometry.location.lng;
+        previousQueryCoordinates.lat = coord.data.candidates[0].geometry.location.lat;
+        previousQueryCoordinates.lng = coord.data.candidates[0].geometry.location.lng;
+      }
+      yelpClient.search({
+        latitude: officialCoordinates.lat,
+        longitude: officialCoordinates.lng,
+        term: 'entertainment',
+        limit: 30,
+        radius: 40000
+      }).then(response => {
+        let events = [];
+        response.jsonBody.businesses.forEach(rest => {
+          let eventObj = {
+            name: rest.name,
+            id: rest.id,
+            photoUrl: rest.image_url,
+            tags: [req.body.destination],
+            mediaType: 'event'
+          };
+          events.push(eventObj);
+        });
+        return res.status(200).json({
+          events: events
+        });
+      }).catch(e => {
+          return res.status(400).json('Something went wrong');
+        });
+      });
+  } else {
+    yelpClient.search({
+      latitude: previousQueryCoordinates.lat,
+      longitude: previousQueryCoordinates.lng,
+      term: eventQueryOptions[eventQueryOptionsCounter],
+      limit: 30,
+      radius: 40000
+    }).then(response => {
+      eventQueryOptionsCounter === eventQueryOptions.length - 1 ? eventQueryOptionsCounter = 0 : eventQueryOptionsCounter = eventQueryOptionsCounter + 1;
+      let events = [];
+      response.jsonBody.businesses.forEach(rest => {
+        let eventObj = {
+          name: rest.name,
+          id: rest.id,
+          photoUrl: rest.image_url,
+          tags: [req.body.destination],
+          mediaType: 'event'
+        };
+        events.push(eventObj);
+      });
+      return res.status(200).json({
+        events: events
+      });
+    }).catch(e => {
+      console.log(' >>>>>>>>>>>>>>>> ' + e);
+        return res.status(400).json('Something went wrong');
+      });
+  }
+}    
+router.post('/', function (req, res, next) {
+  callback(req, res);
+});
+module.exports = router;

--- a/routes/restaurants.js
+++ b/routes/restaurants.js
@@ -1,0 +1,93 @@
+const yelp = require('yelp-fusion');
+var axios = require('axios');
+const { Client } = require('@googlemaps/google-maps-services-js');
+const client = new Client({});
+let axiosInstance = axios.create({});
+const yelpClient = yelp.client('IL2FAbCiYXXpcxEYV6PQVmLctUKFbk5kw-jNKFlx36oMrKjl87A2r6-h8Vs48JiCvyydd7bo0E6ftscdmBEEOC646YYsQCH70GitQwUpR3Yodoa-pAuQREa2LTIbX3Yx');
+var express = require('express');
+var router = express.Router();
+
+let previousQueryCoordinates = {};
+
+async function getPlaceCoordinates (location) {
+  let coordinates = await client
+    .findPlaceFromText({
+      params: {
+        input: location,
+        inputtype: 'textquery',
+        key: 'AIzaSyAKDqQlGYP74UfAeSQDG6h9bKrN6hA0wAA',
+        fields: ['formatted_address', 'geometry']
+      },
+      timeout: 1000
+    }, axiosInstance);
+  return coordinates;
+}
+
+async function callback (req, res) {
+  let officialCoordinates = {};
+  if (!req.body.getMore) {
+    getPlaceCoordinates(req.body.destination)
+    .then(coord => {
+      if (coord.data.candidates.length > 0) {
+        officialCoordinates.lat = coord.data.candidates[0].geometry.location.lat;
+        officialCoordinates.lng = coord.data.candidates[0].geometry.location.lng;
+        previousQueryCoordinates.lat = coord.data.candidates[0].geometry.location.lat;
+        previousQueryCoordinates.lng = coord.data.candidates[0].geometry.location.lng;
+      }
+      yelpClient.search({
+        latitude: officialCoordinates.lat,
+        longitude: officialCoordinates.lng,
+        term: 'food',
+        limit: 50,
+        radius: 40000
+      }).then(response => {
+        let restaurants = [];
+        response.jsonBody.businesses.forEach(rest => {
+          let restaurantObj = {
+            name: rest.name,
+            id: rest.id,
+            photoUrl: rest.image_url,
+            tags: [req.body.destination],
+            mediaType: 'restaurant'
+          };
+          restaurants.push(restaurantObj);
+        });
+        return res.status(200).json({
+          restaurants: restaurants
+        });
+      }).catch(e => {
+          return res.status(400).json('Something went wrong');
+        });
+      });
+  } else {
+    yelpClient.search({
+      latitude: previousQueryCoordinates.lat,
+      longitude: previousQueryCoordinates.lng,
+      term: 'food',
+      limit: 50,
+      radius: 40000,
+      offset: 50
+    }).then(response => {
+      let restaurants = [];
+      response.jsonBody.businesses.forEach(rest => {
+        let restaurantObj = {
+          name: rest.name,
+          id: rest.id,
+          photoUrl: rest.image_url,
+          tags: [req.body.destination],
+          mediaType: 'restaurant'
+        };
+        restaurants.push(restaurantObj);
+      });
+      return res.status(200).json({
+        restaurants: restaurants
+      });
+    }).catch(e => {
+        return res.status(400).json('Something went wrong');
+      });
+  }
+}    
+router.post('/', function (req, res, next) {
+  callback(req, res);
+});
+module.exports = router;


### PR DESCRIPTION
Remember to npm install after pulling these changes.

Also, @qstevens, regarding your suggestion of making the FE handle the calls to third party APIs: the calls to the google API aren't executing properly when they're called from the client, so I'm going to leave all the API calls where they are and not move them to the FE. The yelp API calls rely on a call to the google API as well, so I'll be leaving the yelp calls in the BE as well.